### PR TITLE
Fix AVR compatiblity includes

### DIFF
--- a/arduino-core-mbed.py
+++ b/arduino-core-mbed.py
@@ -96,7 +96,9 @@ env.Append(
     CPPPATH=[
         os.path.join(FRAMEWORK_DIR, "cores", board.get("build.core")),
         os.path.join(FRAMEWORK_DIR, "cores", board.get(
-            "build.core"), "api", "deprecated")
+            "build.core"), "api", "deprecated"),
+        os.path.join(FRAMEWORK_DIR, "cores", board.get(
+            "build.core"), "api", "deprecated-avr-comp")        
     ],
 
     LINKFLAGS=[


### PR DESCRIPTION
[ArduinoCore-mbed does](https://github.com/arduino/ArduinoCore-mbed/blob/7965dce20dcbacb9d7a085d1adb0a5e05ce8b7c1/platform.txt#L73)

```
[...] "-I{build.core.path}/api/deprecated" "-I{build.core.path}/api/deprecated-avr-comp" [..]
```
but PlatformIO fails to do the latter one, leading to compilation errors in libraries needing headers inside `deprecated-avr-comp`.

This PR corrects that.